### PR TITLE
Fix GPG_TTY not a tty issue

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -16,7 +16,7 @@ done
 unset file
 
 ## gpg
-export GPG_TTY=$(tty)
+export GPG_TTY=$TTY
 gpg-connect-agent updatestartuptty /bye
 unset SSH_AGENT_PID
 export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)


### PR DESCRIPTION
See https://unix.stackexchange.com/questions/608842/zshrc-export-gpg-tty-tty-says-not-a-tty
